### PR TITLE
[FEATURE] Allow filtering of results

### DIFF
--- a/class.tx_ddgooglesitemap_dmf.php
+++ b/class.tx_ddgooglesitemap_dmf.php
@@ -88,7 +88,8 @@ class tx_ddgooglesitemap_dmf extends DmitryDulepov\DdGooglesitemap\Generator\TtN
 			$mmTable = $currentSetup['sqlMMTable'];
 			$catColumn = $currentSetup['sqlCatColumn'];
 
-			$sqlCondition = ($catColumn && count($catList) > 0 && $catList[0] > 0) ? ' AND ' . $catColumn . ' IN (' . implode(',', $catList) . ')' : '';
+			$sqlCondition = (empty($currentSetup['sqlWhere']) ? '' : ' AND ' . $currentSetup['sqlWhere']) .
+				(($catColumn && count($catList) > 0 && $catList[0] > 0) ? ' AND ' . $catColumn . ' IN (' . implode(',', $catList) . ')' : '');
 
 			$sqlMMCondition = $sqlMMTable = '';
 			if ($mmTable != '' && count($catMMList) > 0 && $catMMList[0] > 0) {


### PR DESCRIPTION
With an optional `sqlWhere` in the TypoScript settings it's now possible to filter the results.