### PR TITLE
sys_category_record_mm

### DIFF
--- a/class.tx_ddgooglesitemap_dmf.php
+++ b/class.tx_ddgooglesitemap_dmf.php
@@ -97,7 +97,6 @@ class tx_ddgooglesitemap_dmf extends DmitryDulepov\DdGooglesitemap\Generator\TtN
 				
 				if( $mmTable == 'sys_category_record_mm' ){
 				    $sqlMMCondition = 'AND ' . $mmTable . '.tablenames  = "' . $table . '" AND ' . $mmTable . '.fieldname  = "' . $catColumn . '" AND ' . $table . '.uid = ' . $mmTable . '.uid_foreign AND ' . $mmTable . '.uid_local IN (' . implode(',', $catMMList) . ')';
-				    print $sqlMMCondition;
 				}
 			}
 

--- a/class.tx_ddgooglesitemap_dmf.php
+++ b/class.tx_ddgooglesitemap_dmf.php
@@ -94,6 +94,11 @@ class tx_ddgooglesitemap_dmf extends DmitryDulepov\DdGooglesitemap\Generator\TtN
 			if ($mmTable != '' && count($catMMList) > 0 && $catMMList[0] > 0) {
 				$sqlMMTable = ',' . $mmTable;
 				$sqlMMCondition = ' AND ' . $table . '.uid = ' . $mmTable . '.uid_local AND ' . $mmTable . '.uid_foreign IN (' . implode(',', $catMMList) . ')';
+				
+				if( $mmTable == 'sys_category_record_mm' ){
+				    $sqlMMCondition = 'AND ' . $mmTable . '.tablenames  = "' . $table . '" AND ' . $mmTable . '.fieldname  = "' . $catColumn . '" AND ' . $table . '.uid = ' . $mmTable . '.uid_foreign AND ' . $mmTable . '.uid_local IN (' . implode(',', $catMMList) . ')';
+				    print $sqlMMCondition;
+				}
 			}
 
 			$newsSelect = (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('type') == 'news') ? ',' . $currentSetup['sqlTitle'] . ',' . $currentSetup['sqlKeywords'] : '';


### PR DESCRIPTION
If using the sys_category_record_mm table, "uid_foreign" and "uid_local" must be inverted and the matching of the tablename and fieldname must be checked.

Usage :
     
    news {
       # uid is NECESSARY in the sqlSelect field
       sqlMainTable = tx_news_domain_model_news
   
       # if catList depends of column of sqlMainTable (Column name like city or country)
       sqlCatColumn = categories
		
	   # if catList depends on sqlMMTable (Only works if uid_foreign and uid_local is in use)
	   sqlMMTable = sys_category_record_mm
		
	   # order of the XML output
	   sqlOrder = datetime DESC
		
		# last modified timestamp column (inside of sqlMainTable)
		sqlLastUpdated = tstamp
		
	   # sql column of the title
	   sqlTitle = title`
	   
	   # sql column of keywords
		sqlKeywords = keywords
	
	   # frequency
      frequency =
	
      # typolink additionalParam (must belong to the uid of the sqlMainTable)
      linkParams = tx_news_pi1[news]
	
      # csv Pid's of the stored elements. Rootline is not checked with this setting
      pidList = 1,2,3
	
    	# detail page id where the link should point at
    	singlePid = 15
    	
    	# filter by category which is inside of the main table -> sqlCatColumn
    	catList =
		
		# csv filter by mm related table -> sqlMMTable
		catMMList = 3
		
		# disable the language check through GLOBALS['TSFE']->sys_language_uid
		disableLanguageCheck = 0
	}